### PR TITLE
KRANG-1/Extract publishing configuration

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2020 Ivan Milisavljevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}

--- a/buildSrc/src/main/kotlin/publishing.kt
+++ b/buildSrc/src/main/kotlin/publishing.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Ivan Milisavljevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.create
+
+/*
+ * Copyright (C) 2020 Ivan Milisavljevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+const val github = "https://github.com/milis92/Krang"
+
+fun PublishingExtension.withDefaults(project: Project, description: String) {
+    publications {
+        create<MavenPublication>("default") {
+
+            from(project.components.getByName("java"))
+            artifact(project.tasks.getByName("sourcesJar"))
+            artifact(project.tasks.getByName("dokkaJar"))
+
+            pom {
+                name.set(project.name)
+                description.set(description)
+                url.set(github)
+
+                licenses {
+                    license {
+                        name.set("Apache License 2.0")
+                        url.set("$github/blob/main/LICENSE.txt")
+                    }
+                }
+                scm {
+                    url.set(github)
+                    connection.set("$$github.git")
+                }
+                developers {
+                    developer {
+                        name.set("Ivan Milisavljevic")
+                        url.set("https://github.com/milis92")
+                    }
+                }
+            }
+        }
+    }
+
+    repositories {
+        if (
+            project.hasProperty("sonatypeUsername") &&
+            project.hasProperty("sonatypePassword") &&
+            project.hasProperty("sonatypeSnapshotUrl") &&
+            project.hasProperty("sonatypeReleaseUrl")
+        ) {
+            maven {
+                val url = when {
+                    "SNAPSHOT" in project.version.toString() -> project.property("sonatypeSnapshotUrl")
+                    else -> project.property("sonatypeReleaseUrl")
+                } as String
+                setUrl(url)
+                credentials {
+                    username = project.property("sonatypeUsername") as String
+                    password = project.property("sonatypePassword") as String
+                }
+            }
+        }
+        maven {
+            name = "test"
+            setUrl("file://${project.rootProject.buildDir}/localMaven")
+        }
+    }
+}

--- a/krang-compiler-plugin-native/build.gradle.kts
+++ b/krang-compiler-plugin-native/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Ivan Milisavljevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 plugins {
     kotlin("jvm")
     kotlin("kapt")
@@ -50,60 +66,5 @@ signing {
 }
 
 publishing {
-    publications {
-        create<MavenPublication>("default") {
-
-            from(components["java"])
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["dokkaJar"])
-
-            pom {
-                name.set(project.name)
-                description.set("Kotlin Compiler Plugin which adds logging interceptors to the functions")
-                url.set("https://github.com/milis92/Krang")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://github.com/milis92/Krang/blob/master/LICENSE.txt")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/milis92/Krang")
-                    connection.set("https://github.com/milis92/Krang.git")
-                }
-                developers {
-                    developer {
-                        name.set("Ivan Milisavljevic")
-                        url.set("https://github.com/milis92")
-                    }
-                }
-            }
-        }
-    }
-
-    repositories {
-        if (
-            hasProperty("sonatypeUsername") &&
-            hasProperty("sonatypePassword") &&
-            hasProperty("sonatypeSnapshotUrl") &&
-            hasProperty("sonatypeReleaseUrl")
-        ) {
-            maven {
-                val url = when {
-                    "SNAPSHOT" in version.toString() -> property("sonatypeSnapshotUrl")
-                    else -> property("sonatypeReleaseUrl")
-                } as String
-                setUrl(url)
-                credentials {
-                    username = property("sonatypeUsername") as String
-                    password = property("sonatypePassword") as String
-                }
-            }
-        }
-        maven {
-            name = "test"
-            setUrl("file://${rootProject.buildDir}/localMaven")
-        }
-    }
+    withDefaults(project, "Kotlin Compiler Plugin which intercepts and logs function calls")
 }

--- a/krang-compiler-plugin/build.gradle.kts
+++ b/krang-compiler-plugin/build.gradle.kts
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Ivan Milisavljevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 plugins {
     kotlin("jvm")
     kotlin("kapt")
@@ -48,61 +64,5 @@ signing {
 }
 
 publishing {
-    publications {
-        create<MavenPublication>("default") {
-
-            from(components["java"])
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["dokkaJar"])
-
-            pom {
-                name.set(project.name)
-                description.set("Kotlin Compiler Plugin which adds logging interceptors to the functions")
-                url.set("https://github.com/milis92/Krang")
-
-                licenses {
-                    license {
-                        name.set("Apache License 2.0")
-                        url.set("https://github.com/milis92/Krang/blob/master/LICENSE.txt")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/milis92/Krang")
-                    connection.set("https://github.com/milis92/Krang.git")
-                }
-                developers {
-                    developer {
-                        name.set("Ivan Milisavljevic")
-                        url.set("https://github.com/milis92")
-                    }
-                }
-            }
-        }
-    }
-
-    //TODO Check publishing configuration
-    repositories {
-        if (
-            hasProperty("sonatypeUsername") &&
-            hasProperty("sonatypePassword") &&
-            hasProperty("sonatypeSnapshotUrl") &&
-            hasProperty("sonatypeReleaseUrl")
-        ) {
-            maven {
-                val url = when {
-                    "SNAPSHOT" in version.toString() -> property("sonatypeSnapshotUrl")
-                    else -> property("sonatypeReleaseUrl")
-                } as String
-                setUrl(url)
-                credentials {
-                    username = property("sonatypeUsername") as String
-                    password = property("sonatypePassword") as String
-                }
-            }
-        }
-        maven {
-            name = "test"
-            setUrl("file://${rootProject.buildDir}/localMaven")
-        }
-    }
+    withDefaults(project, "Kotlin Compiler Plugin which intercepts and logs function calls")
 }

--- a/krang-runtime/build.gradle.kts
+++ b/krang-runtime/build.gradle.kts
@@ -1,3 +1,48 @@
+/*
+ * Copyright (C) 2020 Ivan Milisavljevic
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 plugins {
     kotlin("jvm")
+    id("org.jetbrains.dokka")
+    id("signing")
+    id("maven-publish")
+}
+
+tasks.register("sourcesJar", Jar::class) {
+    group = "build"
+    description = "Assembles Kotlin sources"
+
+    archiveClassifier.set("sources")
+    from(sourceSets.main.get().allSource)
+    dependsOn(tasks.classes)
+}
+
+tasks.register("dokkaJar", Jar::class) {
+    group = "documentation"
+
+    archiveClassifier.set("javadoc")
+    from(tasks.dokkaJavadoc)
+    dependsOn(tasks.dokkaJavadoc)
+}
+
+signing {
+    setRequired(provider { gradle.taskGraph.hasTask("publish") })
+    sign(publishing.publications)
+}
+
+publishing {
+    withDefaults(project, "Krang runtime")
 }


### PR DESCRIPTION
Extract publishing configuration to a common place

There was a lot of code duplication around maven deployment configuration, this commit extracted that configuration to a common buildScr that can be used across all of the project modules