### PR TITLE
Variant filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Maven metadata URL](https://img.shields.io/maven-metadata/v?label=Release&metadataUrl=https://repo1.maven.org/maven2/com/github/milis92/krang/krang-gradle-plugin/maven-metadata.xml)](https://oss.sonatype.org/content/repositories/snapshots/com/github/milis92/krang/krang-gradle-plugin/)
 [![Maven metadata URL](https://img.shields.io/maven-metadata/v?label=Snapshot&metadataUrl=https://oss.sonatype.org/content/repositories/snapshots/com/github/milis92/krang/krang-gradle-plugin/maven-metadata.xml)](https://oss.sonatype.org/content/repositories/snapshots/com/github/milis92/krang/krang-gradle-plugin/)
 
-Kotlin Compiler plugin that gives you the ability to be notified every time annotated function is called.\
+Kotlin Compiler plugin that gives you the ability to be notified every time annotated function is called.  
 General purpose is for effortless logging or analytics, but it can (but probably shouldn't) be used for more advanced
 use-cases.
 
@@ -15,8 +15,8 @@ use-cases.
 
 ## How does it work
 
-During compilation, Krang injects a small piece of code that's \
-simply firing a callback with a name and parameters of the function passed at runtime.
+During compilation, Krang Compiler Plugin injects a small piece of code at the beginning of a function body,  
+that's simply notifying Krang Runtime that a function with a given name and parameters has been called.
 
 This effectively means Krang is transforming your code in a following way:
 <table>
@@ -56,7 +56,7 @@ class Foo {
 </tr>
 </table>
 
-_Note that this is all done during transformation phase of compilation, your source code won't be polluted by Krang_
+_Note that this is all done during transformation phase of the compilation, your source code won't be polluted by Krang_
 
 ---
 
@@ -64,7 +64,7 @@ _Note that this is all done during transformation phase of compilation, your sou
 
 ### Intercepting individual functions
 
-To get notified every time when a function is called simply annotate that function with `@Intercept` annotation. \
+To get notified every time when a function is called simply annotate that function with `@Intercept` annotation.  
 Note that Krang supports any valid function, for example extension, nested, inline functions, etc.
 
 ```kotlin
@@ -88,7 +88,7 @@ class Foo {
 
 ### Intercepting all functions in a class
 
-In some cases its might be useful to intercept all function calls in a given class.  \
+In some cases its might be useful to intercept all function calls in a given class.  
 To do this, simply annotate desired class with `@Intercept` annotation
 
 ```kotlin
@@ -139,7 +139,7 @@ class Foo {
 
 ### Inheritance
 
-Krang supports inheritance for both class and function transformations. \
+Krang supports inheritance for both class and function transformations.  
 This effectively means that Krang will check if a class or a function overrides a type that has @Intercept or @Redact
 annotations and will apply a transformation based on that.
 
@@ -222,7 +222,7 @@ krang {
 
 ## :cloud: Setup
 
-> Plugin is published on Maven central.\
+> Plugin is published on Maven central.  
 > Note that runtime dependency is automatically applied, and you don't have to add anything explicitly.
 
 <details open>
@@ -285,6 +285,29 @@ apply(plugin = "com.github.milis92.krang")
 ```
 
 </details>
+
+### Variant Filtering
+
+Krang Gradle plugin supports different configurations per variant.  
+This is particularly interesting for Android project, if you for example want to disable Krang for release builds.
+
+```kotlin
+krang {
+    enabled.set(true)
+    godMode.set(true)
+
+    variantFilter {
+        val kotlinCompilation: KotlinCompilation<*> = this
+        when (kotlinCompilation) {
+            is KotlinJvmAndroidCompilation -> {
+                if (kotlinCompilation.androidVariant.buildType.name == "release") {
+                    enabled.set(false)
+                }
+            }
+        }
+    }
+}
+```
 
 ## :cloud: Enabling Kotlin IR backend
 

--- a/dependencies/libs.versions.toml
+++ b/dependencies/libs.versions.toml
@@ -10,7 +10,6 @@ detekt = "1.21.0"
 [libraries]
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api" }
-kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler" }
 kotlin-compilerEmbedable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable" }
 
 gradle-buildConfig = { module = "com.github.gmazzo:gradle-buildconfig-plugin", version.ref = "build-config" }

--- a/krang-compiler-plugin/src/main/kotlin/com/herman/krang/KrangCommandLineProcessor.kt
+++ b/krang-compiler-plugin/src/main/kotlin/com/herman/krang/KrangCommandLineProcessor.kt
@@ -29,7 +29,6 @@ class KrangCommandLineProcessor : CommandLineProcessor {
 
     companion object {
         private const val OPTION_ENABLED = "enabled"
-
         private const val OPTION_GOD_MODE = "godMode"
 
         val ARG_ENABLED = CompilerConfigurationKey<Boolean>(OPTION_ENABLED)

--- a/krang-compiler-plugin/src/main/kotlin/com/herman/krang/internal/KrangRuntime.kt
+++ b/krang-compiler-plugin/src/main/kotlin/com/herman/krang/internal/KrangRuntime.kt
@@ -25,26 +25,18 @@ import org.jetbrains.kotlin.ir.symbols.IrFunctionSymbol
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
 import org.jetbrains.kotlin.name.FqName
 
-/**
- * Reference to the Krang Intercept annotation
- */
+// Reference to the Krang Intercept annotation
 val IrPluginContext.krangInterceptAnnotation: IrClassSymbol
     get() = referenceClass(FqName(Intercept::class.qualifiedName!!)) ?: throw ClassNotFoundException()
 
-/**
- * Reference to the Krang Redact annotation
- */
+// Reference to the Krang Redact annotation
 val IrPluginContext.krangRedactAnnotation: IrClassSymbol
     get() = referenceClass(FqName(Redact::class.qualifiedName!!)) ?: throw ClassNotFoundException()
 
-/**
- * Reference to the runtime
- */
+// Reference to the Krang Runtime
 val IrPluginContext.krangRuntime: IrClassSymbol
     get() = referenceClass(FqName(Krang::class.qualifiedName!!)) ?: throw ClassNotFoundException()
 
-/**
- * Reference to the runtime interceptor function
- */
+// Reference to the runtime interceptor function
 val IrPluginContext.krangInterceptFunctionCall: IrFunctionSymbol
     get() = krangRuntime.getSimpleFunction("notifyListeners")!!

--- a/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradleExtension.kt
+++ b/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradleExtension.kt
@@ -17,23 +17,25 @@
 package com.herman.krang
 
 import org.gradle.api.Named
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import javax.inject.Inject
 
-abstract class KrangGradleExtension @Inject constructor(project: Project) : Named {
+abstract class KrangGradleExtension @Inject constructor(
+    objects: ObjectFactory
+) : Named {
 
     companion object {
         const val extensionName = "krang"
     }
 
+    @Internal
     override fun getName(): String = extensionName
-
-    private val objects = project.objects
 
     // Enable or disable krang at Compile time - true by default
     val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
-    // Enable krang for entier codebase - false by default
+    // Enable krang for entire codebase - false by default
     val godMode: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 }

--- a/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradleExtension.kt
+++ b/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradleExtension.kt
@@ -16,10 +16,12 @@
 
 package com.herman.krang
 
+import org.gradle.api.Action
 import org.gradle.api.Named
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import javax.inject.Inject
 
 abstract class KrangGradleExtension @Inject constructor(
@@ -38,4 +40,12 @@ abstract class KrangGradleExtension @Inject constructor(
 
     // Enable krang for entire codebase - false by default
     val godMode: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+    // Allow krang to support different configurations based on the KotlinCompilation
+    internal var variantFilter: Action<KotlinCompilation<*>>? = null
+
+    @Suppress("unused")
+    fun variantFilter(action: Action<KotlinCompilation<*>>) {
+        variantFilter = action
+    }
 }

--- a/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradlePlugin.kt
+++ b/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradlePlugin.kt
@@ -27,19 +27,24 @@ class KrangGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
     private val runtimeDependency = "${BuildConfig.PLUGIN_GROUP_ID}:krang-runtime:${BuildConfig.PLUGIN_VERSION}"
 
-    override fun apply(target: Project): Unit = with(target) {
+    override fun apply(
+        target: Project
+    ): Unit = with(target) {
         extensions.create(KrangGradleExtension.extensionName, KrangGradleExtension::class.java)
     }
 
-    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+    override fun isApplicable(
+        kotlinCompilation: KotlinCompilation<*>
+    ): Boolean = true
 
     override fun getCompilerPluginId(): String = BuildConfig.PLUGIN_ARTIFACT_ID
 
-    override fun getPluginArtifact(): SubpluginArtifact = SubpluginArtifact(
-        groupId = BuildConfig.PLUGIN_GROUP_ID,
-        artifactId = BuildConfig.PLUGIN_ARTIFACT_ID,
-        version = BuildConfig.PLUGIN_VERSION
-    )
+    override fun getPluginArtifact(): SubpluginArtifact =
+        SubpluginArtifact(
+            groupId = BuildConfig.PLUGIN_GROUP_ID,
+            artifactId = BuildConfig.PLUGIN_ARTIFACT_ID,
+            version = BuildConfig.PLUGIN_VERSION
+        )
 
     override fun applyToCompilation(
         kotlinCompilation: KotlinCompilation<*>
@@ -51,6 +56,7 @@ class KrangGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
         val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(KrangGradleExtension::class.java)
+
         return project.provider {
             listOf(
                 SubpluginOption(key = "enabled", value = extension.enabled.get().toString()),

--- a/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradlePlugin.kt
+++ b/krang-gradle-plugin/src/main/kotlin/com/herman/krang/KrangGradlePlugin.kt
@@ -25,7 +25,10 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 @Suppress("unused")
 class KrangGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
-    private val runtimeDependency = "${BuildConfig.PLUGIN_GROUP_ID}:krang-runtime:${BuildConfig.PLUGIN_VERSION}"
+    companion object {
+        private const val runtimeDependency =
+            "${BuildConfig.PLUGIN_GROUP_ID}:krang-runtime:${BuildConfig.PLUGIN_VERSION}"
+    }
 
     override fun apply(
         target: Project
@@ -57,6 +60,9 @@ class KrangGradlePlugin : KotlinCompilerPluginSupportPlugin {
         val project = kotlinCompilation.target.project
         val extension = project.extensions.getByType(KrangGradleExtension::class.java)
 
+        // Run the optional variant filter to potentially change the config based on the compilation
+        extension.variantFilter?.execute(kotlinCompilation)
+
         return project.provider {
             listOf(
                 SubpluginOption(key = "enabled", value = extension.enabled.get().toString()),
@@ -65,3 +71,4 @@ class KrangGradlePlugin : KotlinCompilerPluginSupportPlugin {
         }
     }
 }
+

--- a/krang-runtime/src/commonMain/kotlin/com/herman/krang/runtime/Krang.kt
+++ b/krang-runtime/src/commonMain/kotlin/com/herman/krang/runtime/Krang.kt
@@ -36,7 +36,10 @@ object Krang {
     }
 
     @Suppress("unused")
-    fun notifyListeners(functionName: String, vararg arguments: Any?) {
+    fun notifyListeners(
+        functionName: String,
+        vararg arguments: Any?
+    ) {
         if (enabled) functionCallListeners.forEach { it.onFunctionCalled(functionName, arguments) }
     }
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("UnstableApiUsage")
 
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
+
 plugins {
     kotlin("multiplatform") version "1.7.10"
     id("com.android.application") version "7.2.2"
@@ -12,6 +15,17 @@ version = "1.0"
 krang {
     enabled.set(true)
     godMode.set(true)
+
+    variantFilter {
+        val kotlinCompilation: KotlinCompilation<*> = this
+        when (kotlinCompilation) {
+            is KotlinJvmAndroidCompilation -> {
+                if (kotlinCompilation.androidVariant.buildType.name == "release") {
+                    enabled.set(false)
+                }
+            }
+        }
+    }
 }
 
 android {


### PR DESCRIPTION
This PR aims to provide the ability for krang to be differently configured based on the kotlin compilation.

Example usage would be
```kotlin
krang {
    enabled.set(true)
    godMode.set(true)

    variantFilter {
        val kotlinCompilation: KotlinCompilation<*> = this
        when (kotlinCompilation) {
            is KotlinJvmAndroidCompilation -> {
                if (kotlinCompilation.androidVariant.buildType.name == "release") {
                    enabled.set(false)
                }
            }
        }
    }
}
```